### PR TITLE
Include unistd.h to define read function

### DIFF
--- a/src/touchscreen.cc
+++ b/src/touchscreen.cc
@@ -3,6 +3,7 @@
 #include <v8.h>
 #include <node.h>
 #include <nan.h>
+#include <unistd.h>
 
 using namespace v8;
 using namespace node;


### PR DESCRIPTION
I had to include unistd.h header in order to build on Raspberry Pi (with Arch Linux).

'read' was not defined in the scope otherwise:

```
touchInfo->read = read(touchInfo->fileDescriptor, touchInfo->inputEvents, sizeof(struct input_event) * 64);
```
